### PR TITLE
XMLSCHEMA-51 Problem with included schemas with attribute group refer…

### DIFF
--- a/xmlschema-core/src/main/java/org/apache/ws/commons/schema/SchemaBuilder.java
+++ b/xmlschema-core/src/main/java/org/apache/ws/commons/schema/SchemaBuilder.java
@@ -805,6 +805,13 @@ public class SchemaBuilder {
         if (offset == -1) {
             uri = pContext.getNamespaceURI(Constants.DEFAULT_NS_PREFIX);
             if (Constants.NULL_NS_URI.equals(uri)) {
+            	if (currentSchema.getTargetNamespace() == null 
+            			&& !currentSchema.getLogicalTargetNamespace().isEmpty()) {
+					// If object is unqualified in a schema without a target namespace then it could
+					// be that this schema is included in another one. The including namespace
+					// should then be used for this reference
+                    return new QName(currentSchema.getLogicalTargetNamespace(), pName);
+            	}
                 return new QName(Constants.NULL_NS_URI, pName);
             }
             localName = pName;

--- a/xmlschema-core/src/test/java/tests/IncludeTest.java
+++ b/xmlschema-core/src/test/java/tests/IncludeTest.java
@@ -38,6 +38,10 @@ import org.apache.ws.commons.schema.XmlSchemaCollection;
 import org.apache.ws.commons.schema.XmlSchemaElement;
 import org.apache.ws.commons.schema.XmlSchemaExternal;
 import org.apache.ws.commons.schema.XmlSchemaInclude;
+import org.apache.ws.commons.schema.XmlSchemaSimpleType;
+import org.apache.ws.commons.schema.XmlSchemaSimpleTypeContent;
+import org.apache.ws.commons.schema.XmlSchemaSimpleTypeUnion;
+import org.apache.ws.commons.schema.XmlSchemaType;
 import org.apache.ws.commons.schema.constants.Constants;
 
 import org.junit.Assert;
@@ -182,4 +186,35 @@ public class IncludeTest extends Assert {
         assertNotNull(el);
         assertNull(el.getAttributeNodeNS(null, "targetNamespace"));
     }
+
+
+    /**
+     * Schema included does not have a namespace and defines a union whose members 
+     * should inherit the root (includer) namespace.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSchemaIncludeUnionWithoutNamespace() throws Exception {
+    	String uri = Resources.asURI("include-union-without-ns/root.xsd");
+        InputSource isource = new InputSource(new FileInputStream(uri));
+        isource.setSystemId(uri);
+        XmlSchemaCollection schemaCol = new XmlSchemaCollection();
+        XmlSchema schema = schemaCol.read(isource);
+        assertNotNull(schema);
+
+        XmlSchemaType uidType = schemaCol.getTypeByQName(new QName("urn:apache-org", "uid"));
+        assertNotNull(uidType);
+        XmlSchemaType oidType = schemaCol.getTypeByQName(new QName("urn:apache-org", "oid"));
+        assertNotNull(oidType);
+        assertTrue(uidType instanceof XmlSchemaSimpleType);
+        XmlSchemaSimpleTypeContent content = ((XmlSchemaSimpleType) uidType).getContent();
+        assertTrue(content instanceof XmlSchemaSimpleTypeUnion);
+        QName oid = ((XmlSchemaSimpleTypeUnion) content).getMemberTypesQNames()[0];
+        assertEquals("oid", oid.getLocalPart());
+        assertEquals("urn:apache-org", oid.getNamespaceURI());
+    }
+    
+    
+
 }

--- a/xmlschema-core/src/test/resources/include-union-without-ns/datatypes.xsd
+++ b/xmlschema-core/src/test/resources/include-union-without-ns/datatypes.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+   <xsd:simpleType name="uid">
+      <xsd:union memberTypes="oid uuid"/>
+   </xsd:simpleType>
+   <xsd:simpleType name="oid">
+      <xsd:restriction base="xsd:string"/>
+   </xsd:simpleType>
+   <xsd:simpleType name="uuid">
+      <xsd:restriction base="xsd:integer"/>
+   </xsd:simpleType>
+</xsd:schema>

--- a/xmlschema-core/src/test/resources/include-union-without-ns/root.xsd
+++ b/xmlschema-core/src/test/resources/include-union-without-ns/root.xsd
@@ -1,0 +1,9 @@
+<xs:schema targetNamespace="urn:apache-org" xmlns="urn:apache-org" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:include schemaLocation="datatypes.xsd"/>
+	<xs:complexType name="Root">
+		<xs:sequence>
+            <xs:element name="number" type="xs:integer"/>
+		</xs:sequence>
+        <xs:attribute name="root" type="uid" use="required"/>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
**What is the problem:** The schema builder constructs list of references for Groups, Unions or Lists. These references are qualified names (QName) that correspond to Type definitions elsewhere in the XML Schema. An issue arises if the member of the union or the group are declared in an XSD that does not have a target namespace and that XSD is included in a root XSD which itself has a target namspace. What should happen in that situation is that all elements from the included XSD should inherit the root target namespace. The issue is that the code that creates such QNames today only takes into consideration the direct XSD parent element and ends up creating QNames with empty namespaces. At the end of the build, the schema is inconsistent because Groups and Unions have references with an empty namespace while the actual element referenced has a namespace.

**What is the solution:** When a reference is created, if it ends up being unqualified, check for the possibility that the current XSD has no namespace but is included in a root XSD that has a namespace. In that case, use the root target namespace.

Note that this is not a perfect solution as there is still a possibility that a member of a union for instance should have an empty namespace. We consider this to be unlikely though and should happen way less often then included XSD without namespace;

A better solution in the long run would be to have a second pass at the end of the build to reconnect references to actual types.