### PR TITLE
Fix bugs regarding substitution groups and content extensions using xs:all

### DIFF
--- a/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaScope.java
+++ b/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaScope.java
@@ -352,7 +352,15 @@ final class XmlSchemaScope {
             } else {
                 XmlSchemaSequence seq = new XmlSchemaSequence();
                 seq.getItems().add((XmlSchemaSequenceMember)baseParticle);
-                seq.getItems().add((XmlSchemaSequenceMember)ext.getParticle());
+                // we cannot cast a SchemaAll instance to SequenceMember
+                if (ext.getParticle() instanceof XmlSchemaAll) {
+                    XmlSchemaAll all = (XmlSchemaAll) ext.getParticle();
+                    for (XmlSchemaAllMember allMember : all.getItems()) {
+                        seq.getItems().add((XmlSchemaSequenceMember) allMember);
+                    }
+                } else {
+                    seq.getItems().add((XmlSchemaSequenceMember) ext.getParticle());
+                }
                 child = seq;
             }
 

--- a/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaWalker.java
+++ b/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaWalker.java
@@ -210,13 +210,7 @@ public final class XmlSchemaWalker {
             element.setMaxOccurs(XmlSchemaParticle.DEFAULT_MAX_OCCURS);
         }
 
-        XmlSchemaType schemaType = element.getSchemaType();
-        if (schemaType == null) {
-            final QName typeQName = element.getSchemaTypeName();
-            if (typeQName != null) {
-                schemaType = schemasByNamespace.getTypeByName(typeQName);
-            }
-        }
+        XmlSchemaType schemaType = getSchemaTypeOfElement(element);
 
         if (schemaType != null) {
             XmlSchemaScope scope = null;
@@ -581,5 +575,22 @@ public final class XmlSchemaWalker {
         } else {
             return element.getQName();
         }
+    }
+
+
+    private XmlSchemaType getSchemaTypeOfElement(XmlSchemaElement element) {
+        XmlSchemaType schemaType = element.getSchemaType();
+        if (schemaType == null) {
+            final QName typeQName = element.getSchemaTypeName();
+            if (typeQName != null) {
+                schemaType = schemasByNamespace.getTypeByName(typeQName);
+            } else {
+                final QName substitutionGroupQName = element.getSubstitutionGroup();
+                if (substitutionGroupQName != null) {
+                    schemaType = getSchemaTypeOfElement(schemasByNamespace.getElementByName(substitutionGroupQName));
+                }
+            }
+        }
+        return schemaType;
     }
 }


### PR DESCRIPTION
I have come across two bugs for which I provide basic fixes here.

1. If an element with a substitutionGroup did not have an explicit type, an IllegalStateException was thrown because of `schemaType == null` and `!element.isAbstract()`. Example:
```
<xs:element name="any" type="SimpleLiteral" abstract="true"/>
<xs:element name="title" substitutionGroup="any"/>
```
Here, the exception occurred when walking through the title element. My fix now considers the type of the substitutionGroup element if no explicit is given.

2. A ClassCastException happened when a particle of type xs:all occurred in an xs:extension, e.g. 
```
<xs:complexContent>
	<xs:extension base="baseType">
		<xs:all> ...
```
I added a simple check and add the xs:all items to the constructed sequence separately.