### PR TITLE
[WSCOMMONS-578] StackOverflowError occurs in XmlSchema.getAllSchemas()

### DIFF
--- a/xmlschema-core/src/test/java/tests/CircularSchemaTest.java
+++ b/xmlschema-core/src/test/java/tests/CircularSchemaTest.java
@@ -28,6 +28,7 @@ import org.apache.ws.commons.schema.XmlSchemaCollection;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
 
 public class CircularSchemaTest extends Assert {
     @Test
@@ -42,5 +43,19 @@ public class CircularSchemaTest extends Assert {
         XmlSchema[] xmlSchemas = schemas.getXmlSchemas();
         assertNotNull(xmlSchemas);
         assertEquals(3, xmlSchemas.length);
+    }
+    
+    @Test
+    public void testCircularSerialization() throws Exception {
+        XmlSchemaCollection schemas = new XmlSchemaCollection();
+        File file = new File(Resources.asURI("circular/a.xsd"));
+        InputSource source = new InputSource(new FileInputStream(file));
+        source.setSystemId(file.toURI().toURL().toString());
+
+        XmlSchema xmlSchema = schemas.read(source);
+        
+        Document[] allSchemas = xmlSchema.getAllSchemas();
+        assertNotNull(allSchemas);
+        assertEquals(2, allSchemas.length);
     }
 }


### PR DESCRIPTION
Fixes this bug in XmlSchemaSerializer: [WSCOMMONS-578](https://issues.apache.org/jira/browse/WSCOMMONS-578)

We've been using this modification for many years, I'd like to get it upstream.